### PR TITLE
Updated constructors for PHP 7 compatibility

### DIFF
--- a/core/core.php
+++ b/core/core.php
@@ -37,7 +37,7 @@ class wsBrokenLinkChecker {
    * @param blcConfigurationManager $conf An instance of the configuration manager
    * @return void
    */
-    function wsBrokenLinkChecker ( $loader, $conf ) {
+    function __construct ( $loader, $conf ) {
 		$this->db_version = BLC_DATABASE_VERSION;
         
         $this->conf = $conf;

--- a/includes/config-manager.php
+++ b/includes/config-manager.php
@@ -20,7 +20,7 @@ class blcConfigurationManager {
 	 */
 	public $db_option_loaded = false;
 	
-	function blcConfigurationManager( $option_name = '', $default_settings = null ){
+	function __construct( $option_name = '', $default_settings = null ){
 		$this->option_name = $option_name;
 		
 		if ( is_array($default_settings) ){

--- a/includes/module-base.php
+++ b/includes/module-base.php
@@ -29,7 +29,7 @@ class blcModule {
 	 * @param blcModuleManager $module_manager
 	 * @return void
 	 */
-	function blcModule($module_id, $cached_header, &$plugin_conf, &$module_manager){
+	function __construct($module_id, $cached_header, &$plugin_conf, &$module_manager){
 		$this->module_id = $module_id;
 		$this->cached_header = $cached_header;
 		$this->plugin_conf = &$plugin_conf;

--- a/includes/screen-meta-links.php
+++ b/includes/screen-meta-links.php
@@ -28,7 +28,7 @@ class wsScreenMetaLinks11 {
 	 * 
 	 * @return void
 	 */
-	function wsScreenMetaLinks11(){
+	function __construct(){
 		$this->registered_links = array();
 		
 		add_action('admin_notices', array(&$this, 'append_meta_links'));


### PR DESCRIPTION
Some classes had PHP 4 constructors which are now deprecated.
http://php.net/manual/en/migration70.deprecated.php