### PR TITLE
Add filters to define additional cUrl options

### DIFF
--- a/modules/checkers/http.php
+++ b/modules/checkers/http.php
@@ -322,7 +322,7 @@ class blcCurlHttp extends blcHttpCheckerBase {
 
 
         // Apply filter before curl closes
-        apply_filters('broken-link-checker-curl-before-close', $ch);
+        apply_filters('broken-link-checker-curl-before-close', $ch, $content, $this->last_headers);
 
         curl_close($ch);
 

--- a/modules/checkers/http.php
+++ b/modules/checkers/http.php
@@ -254,6 +254,9 @@ class blcCurlHttp extends blcHttpCheckerBase {
 			curl_setopt($ch, CURLINFO_HEADER_OUT, true);
 		}
 
+        // Apply filter for additional options
+        curl_setopt_array($ch, apply_filters('broken-link-checker-curl-options', array()) );
+
 		//Execute the request
 		$start_time = microtime_float();
         $content = curl_exec($ch);
@@ -316,6 +319,11 @@ class blcCurlHttp extends blcHttpCheckerBase {
         } else {
         	$result['broken'] = $this->is_error_code($result['http_code']);
         }
+
+
+        // Apply filter before curl closes
+        apply_filters('broken-link-checker-curl-before-close', $ch);
+
         curl_close($ch);
 
 		$blclog->info(sprintf(


### PR DESCRIPTION
I had the issue, that a site redirected to an "please enable cookies page" when cookies where not enabled. So broken link checker thought the site was found as a 200 return message was retuned (which could be wrong).

Therefore i would like to have two additional filter:
1. broken-link-checker-curl-options -> to define additional cUrl options such as CURLOPT_COOKIEFILE for example
2. broken-link-checker-curl-before-close -> to do some additional actions such as remove the stored cookie files before the cUrl request is closed.

I'm sure there are other additional options which could be helpful. Or are there any other possibilities to resolve my issue.

Additionally I could also extend the options, like "enable cookies".
 