### PR TITLE
Use Internet Archive suggestions and lookup over HTTPS

### DIFF
--- a/includes/admin/links-page-js.php
+++ b/includes/admin/links-page-js.php
@@ -436,7 +436,7 @@ jQuery(function($){
 
 		//Check the Wayback Machine for an archived version of the page.
 		$.getJSON(
-			'//archive.org/wayback/available?callback=?',
+			'https://archive.org/wayback/available?callback=?',
 			{ url: url },
 
 			function(data) {
@@ -455,6 +455,9 @@ jQuery(function($){
 					'-' + snapshot.timestamp.substr(4, 2) +
 					'-'	+ snapshot.timestamp.substr(6, 2);
 				var name = sprintf(iaSuggestionName, readableTimestamp);
+
+				//Enforce HTTPS by default
+				snapshot.url = (snapshot.url).replace( new RegExp("^http:", "m"), "https:");
 
 				//Display the suggestion.
 				var item = suggestionTemplate.clone();


### PR DESCRIPTION
Enforce HTTPS by default. Wayback Machine does [this very thing](https://github.com/internetarchive/FirefoxNoMore404s/blob/4f8d9624859282aa245ce02077bb76dba80ea7a8/src/scripts/background.js#L96) themselves in their Wayback Machine browser plugin.

Even though this project’s license is currently unclear, [I agree to having my code distributed](https://github.com/ManageWP/broken-link-checker/issues/26).