### PR TITLE
Feature/hughe speedup cleanup process

### DIFF
--- a/includes/any-post.php
+++ b/includes/any-post.php
@@ -156,7 +156,7 @@ class blcPostTypeOverlord {
 			$current_link_ids = wp_list_pluck( $q_current_link_ids_results, 'link_id' );
 
 			// Go ahead and remove blc_instances for this container, blc_cleanup_links( $current_link_ids ) will find and remove any dangling links in the blc_links table
-			$wpdb->query( 'DELETE FROM `'.$wpdb->prefix.'_blc_instances` WHERE instance_id IN (\''.implode("', '", $current_instance_ids).'\')';
+			$wpdb->query( 'DELETE FROM `'.$wpdb->prefix.'_blc_instances` WHERE instance_id IN (\''.implode("', '", $current_instance_ids).'\')' );
 
 			//Clean up any dangling links
 			blc_cleanup_links( $current_link_ids );

--- a/includes/any-post.php
+++ b/includes/any-post.php
@@ -133,8 +133,6 @@ class blcPostTypeOverlord {
 			//Delete the container
 			$post_container->delete();
 
-			$link_ids = NULL;
-
 			// Firstly: See if we have any current instances
 			$q_current_instance_ids = $wpdb->prepare( 
 				'SELECT instance_id FROM `'.$wpdb->prefix.'_blc_instances` WHERE container_id = %d AND container_type = %s', 
@@ -150,37 +148,18 @@ class blcPostTypeOverlord {
 
 			$current_instance_ids = wp_list_pluck( $current_instance_ids_results, 'instance_id' );
 
-			// Secondly: Get the link_ids used in our current instances
+			// Secondly: Get all link_ids used in our current instances
 			$q_current_link_ids = 'SELECT DISTINCT link_id FROM `'.$wpdb->prefix.'_blc_instances` WHERE instance_id IN (\''.implode("', '", $current_instance_ids).'\')';
 
 			$q_current_link_ids_results = $wpdb->get_results( $q_current_link_ids, ARRAY_A );
 
 			$current_link_ids = wp_list_pluck( $q_current_link_ids_results, 'link_id' );
 
-
-			// Thirdly: Check if any OTHER instances use the same link_ids
-			$q_other_link_ids = 'SELECT DISTINCT link_id FROM `'.$wpdb->prefix.'_blc_instances` WHERE link_id IN (\''.implode("', '", $current_link_ids).'\') AND instance_id NOT IN (\''.implode("', '", $current_instance_ids).'\')';
-
-			$other_link_ids_results = $wpdb->get_results( $q_other_link_ids, ARRAY_A );
-
-			if( $wpdb->num_rows == 0 ) {
-				// No other usage in other instances, delete them all
-				$link_ids = $current_link_ids;
-			} else {
-				// We have found some links that are used by other instances as well
-				// Determine uniqueness
-				$other_link_ids = wp_list_pluck( $other_link_ids_results, 'link_id' );
-				$link_ids = array_diff( $current_link_ids, $other_link_ids );
-
-				// If they share the very same links, bail as well
-				if( $link_ids == array() ) {
-					return;
-				}
-			}
-
+			// Go ahead and remove blc_instances for this container, blc_cleanup_links( $current_link_ids ) will find and remove any dangling links in the blc_links table
+			$wpdb->query( 'DELETE FROM `'.$wpdb->prefix.'_blc_instances` WHERE instance_id IN (\''.implode("', '", $current_instance_ids).'\')';
 
 			//Clean up any dangling links
-			blc_cleanup_links( $link_ids );
+			blc_cleanup_links( $current_link_ids );
 		}
 	}
 	


### PR DESCRIPTION
We encountered long (50 seconds) delays from the mysql query in blc_cleanup_links() when removing posts to trash. (3K blc instances, 2,4K blc links, 3K blc synch containers, 52K WP post records)

It appeared the query in blc_cleanup_links() does a LEFT JOIN on 2 full tables (link with instance). Yet it was already capable of having an array (or int) of link_ids.

So .. in the new code in post_deleted() we will do the following:
See if we have any current instances -> if not ... bail
Followed by a simple list of all used link_ids in the current CPT and a delete in the instance table.
Lastly it will call blc_cleanup_links() with the current link_ids found to speed up the join and delete process in blc_cleanup_links().

In our case this speeds up the mysql/php time by over 49 seconds. 