### PR TITLE
Add filter for HTML Link parser content

### DIFF
--- a/modules/parsers/html_link.php
+++ b/modules/parsers/html_link.php
@@ -27,7 +27,7 @@ class blcHTMLLink extends blcParser {
    * @return array An array of new blcLinkInstance objects. The objects will include info about the links found, but not about the corresponding container entity. 
    */
 	function parse($content, $base_url = '', $default_link_text = ''){
-	    $content = apply_filters( 'blc-parser-html-link-content', $content );
+		$content = apply_filters( 'blc-parser-html-link-content', $content );
 
 		//remove all <code></code> blocks first
 		$content = preg_replace('/<code[^>]*>.+?<\/code>/si', ' ', $content);

--- a/modules/parsers/html_link.php
+++ b/modules/parsers/html_link.php
@@ -27,6 +27,8 @@ class blcHTMLLink extends blcParser {
    * @return array An array of new blcLinkInstance objects. The objects will include info about the links found, but not about the corresponding container entity. 
    */
 	function parse($content, $base_url = '', $default_link_text = ''){
+	    $content = apply_filters( 'blc-parser-html-link-content', $content );
+
 		//remove all <code></code> blocks first
 		$content = preg_replace('/<code[^>]*>.+?<\/code>/si', ' ', $content);
 		


### PR DESCRIPTION
Hi,

We have a site that uses Visual Composer for building pages. VC has _vc_link_ shortcode which saves the link in `url:value|title:value|target:value|` format, which does not get picked up by BLC. With this filter in place we can format these kind of links beforehand and add them as normal HTML links to the content before it is parsed by BLC.

Br,
Tomi