### PR TITLE
Replace deprecated call to `create_function` for PHP 7.2

### DIFF
--- a/modules/checkers/http.php
+++ b/modules/checkers/http.php
@@ -144,7 +144,7 @@ class blcHttpCheckerBase extends blcChecker {
 		//TODO: Remove/fix this. Probably not a good idea to "fix" invalid URLs like that.  
 		return preg_replace_callback(
 			'|[^a-z0-9\+\-\/\\#:.,;=?!&%@()$\|*~_]|i', 
-			create_function('$str','return rawurlencode($str[0]);'), 
+			function($str) { return rawurlencode($str[0]); }, 
 			$url
 		 );
 	}


### PR DESCRIPTION
`create_function()` was deprecated in 7.2 and generates a warning. This replaces the call with an anonymous function, the new preferred way.

See http://php.net/manual/en/function.create-function.php for details.